### PR TITLE
Fix Vm dimentions in docstring

### DIFF
--- a/thermo/chemical.py
+++ b/thermo/chemical.py
@@ -1727,7 +1727,7 @@ class Chemical(object): # pragma: no cover
     @property
     def Vms(self):
         r'''Solid-phase molar volume of the chemical at its current
-        temperature, in units of [mol/m^3]. For calculation of this property at
+        temperature, in units of [m^3/mol]. For calculation of this property at
         other temperatures, or specifying manually the method used to calculate
         it, and more - see the object oriented interface
         :obj:`thermo.volume.VolumeSolid`; each Chemical instance
@@ -1743,7 +1743,7 @@ class Chemical(object): # pragma: no cover
     @property
     def Vml(self):
         r'''Liquid-phase molar volume of the chemical at its current
-        temperature and pressure, in units of [mol/m^3]. For calculation of this
+        temperature and pressure, in units of [m^3/mol]. For calculation of this
         property at other temperatures or pressures, or specifying manually the
         method used to calculate it, and more - see the object oriented interface
         :obj:`thermo.volume.VolumeLiquid`; each Chemical instance
@@ -1759,7 +1759,7 @@ class Chemical(object): # pragma: no cover
     @property
     def Vmg(self):
         r'''Gas-phase molar volume of the chemical at its current
-        temperature and pressure, in units of [mol/m^3]. For calculation of this
+        temperature and pressure, in units of [m^3/mol]. For calculation of this
         property at other temperatures or pressures, or specifying manually the
         method used to calculate it, and more - see the object oriented interface
         :obj:`thermo.volume.VolumeGas`; each Chemical instance

--- a/thermo/mixture.py
+++ b/thermo/mixture.py
@@ -1263,7 +1263,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vmss(self):
         r'''Pure component solid-phase molar volumes of the chemicals in the
-        mixture at its current temperature, in units of [mol/m^3].
+        mixture at its current temperature, in units of [m^3/mol].
 
         Examples
         --------
@@ -1275,7 +1275,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vmls(self):
         r'''Pure component liquid-phase molar volumes of the chemicals in the
-        mixture at its current temperature and pressure, in units of [mol/m^3].
+        mixture at its current temperature and pressure, in units of [m^3/mol].
 
         Examples
         --------
@@ -1287,7 +1287,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vmgs(self):
         r'''Pure component gas-phase molar volumes of the chemicals in the
-        mixture at its current temperature and pressure, in units of [mol/m^3].
+        mixture at its current temperature and pressure, in units of [m^3/mol].
 
         Examples
         --------
@@ -2140,7 +2140,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vml(self):
         r'''Liquid-phase molar volume of the mixture at its current
-        temperature, pressure, and composition in units of [mol/m^3]. For
+        temperature, pressure, and composition in units of [m^3/mol]. For
         calculation of this property at other temperatures or pressures or
         compositions, or specifying manually the method used to calculate it,
         and more - see the object oriented interface
@@ -2157,7 +2157,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vmg(self):
         r'''Gas-phase molar volume of the mixture at its current
-        temperature, pressure, and composition in units of [mol/m^3]. For
+        temperature, pressure, and composition in units of [m^3/mol]. For
         calculation of this property at other temperatures or pressures or
         compositions, or specifying manually the method used to calculate it,
         and more - see the object oriented interface
@@ -2497,7 +2497,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vml_STP(self):
         r'''Liquid-phase molar volume of the mixture at 298.15 K and 101.325 kPa,
-        and the current composition in units of [mol/m^3].
+        and the current composition in units of [m^3/mol].
 
         Examples
         --------
@@ -2509,7 +2509,7 @@ Pa>' % (self.names, [round(i,4) for i in self.zs], self.T, self.P)
     @property
     def Vmg_STP(self):
         r'''Gas-phase molar volume of the mixture at 298.15 K and 101.325 kPa,
-        and the current composition in units of [mol/m^3].
+        and the current composition in units of [m^3/mol].
 
         Examples
         --------


### PR DESCRIPTION
The molar volume dimensions were wrong in the docstrings, so I changed them.