### PR TITLE
Minor enhancements to T and TPDependentProperty objects

### DIFF
--- a/thermo/unifac.py
+++ b/thermo/unifac.py
@@ -3569,13 +3569,15 @@ class UNIFAC(GibbsExcess):
             Object for performing calculations with the UNIFAC activity
             coefficient model, [-]
 
-        Warning
-        -------
-        For version 0, the interaction data and subgroups default to the 
-        original UNIFAC model (not LLE). 
+        Notes
+        -----
         
-        For version 1, the interaction data defaults to the Dortmund parameters
-        publshed in 2016 (not 2006).
+        .. warning::
+            For version 0, the interaction data and subgroups default to the 
+            original UNIFAC model (not LLE). 
+            
+            For version 1, the interaction data defaults to the Dortmund parameters
+            publshed in 2016 (not 2006).
 
         Examples
         --------

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -2142,9 +2142,6 @@ class TDependentProperty(object):
             raise ValueError("The given method is not available for this chemical")
         self.T_cached = None
         self._method = method
-        extrapolation = getattr(self, '_extrapolation', None)
-        if extrapolation is not None and method is not None:
-            self._load_extrapolation_coeffs(method)
 
     def valid_methods(self, T=None):
         r'''Method to obtain a sorted list of methods that have data
@@ -3197,7 +3194,6 @@ class TDependentProperty(object):
             self._extrapolation_low = self._extrapolation_high = self.extrapolations = None
             return
         self.extrapolation_split = '|' in extrapolation
-
         if not self.extrapolation_split:
             extrapolations = [extrapolation]
             self._extrapolation_low = self._extrapolation_high = extrapolation
@@ -3209,8 +3205,6 @@ class TDependentProperty(object):
             if extrapolations[0] == extrapolations[1]:
                 extrapolations.pop()
         self.extrapolations = extrapolations
-        method = getattr(self, '_method', None)
-        if method is not None: self._load_extrapolation_coeffs(method)
 
     def extrapolate(self, T, method, in_range='error'):
         r'''Method to perform extrapolation on a given method according to the

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -2139,11 +2139,12 @@ class TDependentProperty(object):
     @method.setter
     def method(self, method):
         if method not in self.all_methods and method != POLY_FIT and method is not None:
-            raise ValueError("The given methods is not available for this chemical")
+            raise ValueError("The given method is not available for this chemical")
         self.T_cached = None
         self._method = method
         extrapolation = getattr(self, '_extrapolation', None)
-        if extrapolation is not None: self.extrapolation = extrapolation
+        if extrapolation is not None and method is not None:
+            self._load_extrapolation_coeffs(method)
 
     def valid_methods(self, T=None):
         r'''Method to obtain a sorted list of methods that have data
@@ -3536,12 +3537,13 @@ class TPDependentProperty(TDependentProperty):
             for name, (Ts, Ps, properties) in kwargs['tabular_data_P'].items():
                 self.add_tabular_data_P(Ts, Ps, properties, name=name, check_properties=False)
 
-        method_P = kwargs.get('method_P', None)
-        all_methods_P = self.all_methods_P
-        for i in self.ranked_methods_P: 
-            if i in all_methods_P:
-                method_P = i
-                break
+        method_P = kwargs.get('method_P', getattr(self, '_method_P', None))
+        if method_P is None:
+            all_methods_P = self.all_methods_P
+            for i in self.ranked_methods_P: 
+                if i in all_methods_P:
+                    method_P = i
+                    break
         self.method_P = method_P
         
     @property

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -2367,7 +2367,7 @@ class TDependentProperty(object):
         prop : float
             Calculated property, [`units`]
         '''
-        method = self.method
+        method = self._method
         if method == POLY_FIT:
             try: return self.calculate(T, POLY_FIT)
             except: return None

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -42,7 +42,7 @@ Temperature Dependent
              calculate_integral_over_T, T_dependent_property_integral_over_T,
              extrapolate, test_method_validity, calculate, from_json, as_json,
              interpolation_T, interpolation_T_inv, interpolation_property,
-             interpolation_property_inv, T_limits, all_methods, __repr__,
+             interpolation_property_inv, T_limits, __repr__,
              add_correlation
    :undoc-members:
 
@@ -55,7 +55,7 @@ Temperature and Pressure Dependent
              add_method, add_tabular_data, solve_property,
              extrapolate, test_method_validity, calculate,
              interpolation_T, interpolation_T_inv, interpolation_property,
-             interpolation_property_inv, T_limits, all_methods, all_methods_P,
+             interpolation_property_inv, T_limits,
              method_P, valid_methods_P, TP_dependent_property,
              TP_or_T_dependent_property, add_tabular_data_P, plot_isotherm,
              plot_isobar, plot_TP_dependent_property, calculate_derivative_T,

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -4303,14 +4303,14 @@ class MixtureProperty(object):
         '''user_methods, list: Stored methods which were specified by the user
         in a ranked order of preference; set by :obj:`mixture_property <thermo.utils.MixtureProperty.mixture_property>`.'''
         
-        self.method = kwargs.get('method', None)
-        
         self.all_methods = set()
         '''Set of all methods available for a given set of information;
         filled by :obj:`load_all_methods`.'''
         self.load_all_methods()
 
         self.set_poly_fit_coeffs()
+        
+        if 'method' in kwargs: self.method = kwargs['method']
 
     def as_json(self, references=1):
         r'''Method to create a JSON serialization of the mixture property

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -3231,7 +3231,7 @@ class TDependentProperty(object):
         '''
         try:
             return self._extrapolate(T, method, in_range)
-        except AttributeError:
+        except (AttributeError, KeyError):
             self._load_extrapolation_coeffs(method)
             return self._extrapolate(T, method, in_range)
         


### PR DESCRIPTION
Hi Caleb,

This pull request is meant to clean-up and speed up T and TPDependentProperty objects. Main changes include:
* Remove unused attributes (probably from version 0.1), including `sorted_valid_methods`, which is an empty list that offers no functionality.
* Remove double documented attributes, such as "all_methods".
* Remove class attributes such as "_method", which are always initialized in `__init__`.
* Speed up `valid_methods` and `valid_methods_P` (made algorithm changes that do not affect the end result).
* Prevent loading extrapolation coefficients during initialization (and attempting to reload each time a method is set). Now coefficients are only loaded as needed.

The above changes speed up initialization of some T and TPDependentProperty objects by about 10 us (or 20% of the total creation time). The actual time varies depending on the chemical and the subclass of course.

These are minor changes (and all tests are passing), but just wanted to run this by you just in case I missed something.

Thanks! 