### PR TITLE
User methods (for pure chemicals)

### DIFF
--- a/tests/test_user_methods.py
+++ b/tests/test_user_methods.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+'''Chemical Engineering Design Library (ChEDL). Utilities for process modeling.
+Copyright (C) 2016, Caleb Bell <Caleb.Andrew.Bell@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.'''
+from fluids.numerics import assert_close
+import pytest
+from math import log
+from thermo.utils import TDependentProperty
+
+def test_user_constant_method():
+    # Test user defined method
+    
+    # Within valid T range
+    obj = TDependentProperty(extrapolation='linear')
+    constant = 100.
+    T1 = T = 300.
+    T2 = 310.
+    dT = T2 - T1
+    obj.set_user_method(constant)
+    assert_close(obj.T_dependent_property(T), constant)
+    for order in (1, 2, 3):
+        assert_close(obj.T_dependent_property_derivative(T, order), 0.)
+    assert_close(obj.T_dependent_property_integral(T1, T2), constant * dT)
+    assert_close(obj.T_dependent_property_integral_over_T(T1, T2), constant * log(T2 / T1))
+    
+    # Extrapolate
+    Tmin = 350.
+    Tmax = 400.
+    obj.set_user_method(constant, Tmin, Tmax)
+    obj.extrapolation = 'constant'
+    assert_close(obj.T_dependent_property(T), constant)
+    for order in (1, 2, 3):
+        assert_close(obj.T_dependent_property_derivative(T, order), 0., atol=1e-6)
+    assert_close(obj.T_dependent_property_integral(T1, T2), constant * dT)
+    assert_close(obj.T_dependent_property_integral_over_T(T1, T2), constant * log(T2 / T1))
+    
+    # Do not allow extrapolation
+    obj.extrapolation = None
+    obj.set_user_method(constant, Tmin, Tmax)
+    assert obj.T_dependent_property(T) is None
+    for order in (1, 2, 3):
+        assert obj.T_dependent_property_derivative(T, order) is None
+    # assert obj.T_dependent_property_integral(T, T+10.) is None
+    # assert obj.T_dependent_property_integral_over_T(T, T+10) is None
+    
+def test_user_method():
+    # Test user defined method
+    
+    # Within valid T range
+    obj = TDependentProperty(extrapolation='linear')
+    T = 300.
+    Tmin = 200.
+    Tmax = 400.
+    T1 = T = 300.
+    T2 = 310.
+    dT = T2 - T1
+    f = lambda T: T*T / 1e6
+    f_der = lambda T: T / 1e6
+    f_der2 = lambda T: 1. / 1e6
+    f_der3 = lambda T: 0. / 1e6
+    f_int = lambda T1, T2: (T2*T2*T2 - T1*T1*T1) / 3. / 1e6
+    f_int_over_T = lambda T1, T2: (T2*T2 - T1*T1) / 2. / 1e6
+    obj.set_user_method(f, Tmin, Tmax, f_der, f_der2, f_der3, f_int, f_int_over_T)
+    assert_close(obj.T_dependent_property(T), f(T))
+    assert_close(obj.T_dependent_property_derivative(T, 1), f_der(T))
+    assert_close(obj.T_dependent_property_derivative(T, 2), f_der2(T))
+    assert_close(obj.T_dependent_property_derivative(T, 3), f_der3(T))
+    assert_close(obj.T_dependent_property_integral(T1, T2), f_int(T1, T2))
+    assert_close(obj.T_dependent_property_integral_over_T(T1, T2), f_int_over_T(T1, T2))
+    
+    # Extrapolate
+    Tmin = 300. + 1e-3
+    obj.set_user_method(f, Tmin, Tmax)
+    assert_close(obj.T_dependent_property(T), f(T))
+    for order in (1, 2, 3):
+        assert obj.T_dependent_property_derivative(T, order) is not None
+    assert_close(obj.T_dependent_property_integral(T1, T2), f_int(T1, T2))
+    assert_close(obj.T_dependent_property_integral_over_T(T1, T2), f_int_over_T(T1, T2))
+    
+    # Do not allow extrapolation
+    obj.extrapolation = None
+    obj.set_user_method(f, Tmin, Tmax)
+    assert obj.T_dependent_property(T) is None
+    for order in (1, 2, 3):
+        assert obj.T_dependent_property_derivative(T, order) is None
+    # assert obj.T_dependent_property_integral(T, T+10.) is None
+    # assert obj.T_dependent_property_integral_over_T(T, T+10) is None

--- a/thermo/heat_capacity.py
+++ b/thermo/heat_capacity.py
@@ -278,7 +278,6 @@ class HeatCapacityGas(TDependentProperty):
         self.similarity_variable = similarity_variable
         super(HeatCapacityGas, self).__init__(extrapolation, **kwargs)
 
-
     def load_all_methods(self, load_data=True):
         r'''Method which picks out coefficients for the specified chemical
         from the various dictionaries and DataFrames storing it. All data is
@@ -1266,7 +1265,6 @@ class HeatCapacitySolid(TDependentProperty):
         self.all_methods = set(methods)
         if Tmins and Tmaxs:
             self.Tmin, self.Tmax = min(Tmins), max(Tmaxs)
-
 
     def calculate(self, T, method):
         r'''Method to calculate heat capacity of a solid at temperature `T`

--- a/thermo/permittivity.py
+++ b/thermo/permittivity.py
@@ -216,8 +216,8 @@ class PermittivityLiquid(TDependentProperty):
             epsilon = A + T*(B + T*(C + D*T))
         elif method == CRC_CONSTANT:
             epsilon = self.CRC_permittivity
-        elif method in self.tabular_data:
-            epsilon = self.interpolate(T, method)
+        else:
+            epsilon = self._base_calculate(T, self._method)
         return epsilon
 
     def test_method_validity(self, T, method):

--- a/thermo/utils.py
+++ b/thermo/utils.py
@@ -120,6 +120,8 @@ from thermo.eos_mix import GCEOSMIX
 from thermo.coolprop import coolprop_fluids
 from thermo.fitting import data_fit_statistics
 import thermo
+
+USER_METHOD = 'USER_METHOD'
 NEGLIGIBLE = 'NEGLIGIBLE'
 DIPPR_PERRY_8E = 'DIPPR_PERRY_8E'
 POLY_FIT = 'POLY_FIT'
@@ -754,6 +756,56 @@ def generate_fitting_function(model,
             return f(Ts, *reusable_args)
     return fitting_function
 
+def user_method(f, f_der, f_der2, f_der3, f_int, f_int_over_T):
+    if callable(f):
+        return UserMethod(f, f_der, f_der2, f_der3, f_int, f_int_over_T)
+    else:
+        try: 
+            value = float(f)
+        except:
+            raise ValueError("`f` must be either a callable or a number")
+        if not all([i is None for i in (f_der, f_der2, f_der3, f_int, f_int_over_T)]):
+            raise ValueError("cannot define derivatives and integrals "
+                             "when `f` is a number")
+        return ConstantUserMethod(value)
+
+class UserMethod:
+    __slots__ = ('f', 'f_der', 'f_der2', 'f_der3', 'f_int', 'f_int_over_T')
+    
+    def __init__(self, f, f_der, f_der2, f_der3, f_int, f_int_over_T):
+        self.f = f
+        self.f_der = f_der
+        self.f_der2 = f_der2
+        self.f_der3 = f_der3
+        self.f_int = f_int
+        self.f_int_over_T = f_int_over_T
+
+
+class ConstantUserMethod:
+    __slots__ = ('value',)
+    
+    def __init__(self, value):
+        self.value = value
+        
+    def f(self, T):
+        return self.value
+      
+    def f_der(self, T):
+        return 0.
+    
+    def f_der2(self, T):
+        return 0.
+    
+    def f_der3(self, T):
+        return 0.
+        
+    def f_int(self, Ta, Tb):
+        return self.value * (Tb - Ta)
+
+    def f_int_over_T(self, Ta, Tb):
+        return self.value * log(Tb/Ta)
+
+
 class TDependentProperty(object):
     '''Class for calculating temperature-dependent chemical properties.
 
@@ -902,9 +954,6 @@ class TDependentProperty(object):
     critical point. This is used by numerical solvers.'''
 
     ranked_methods = []
-
-    # For methods specified by a user
-    local_methods = {}
 
     _fit_force_n = {}
     '''Dictionary containing method: fit_n, for use in methods which should
@@ -2329,8 +2378,8 @@ class TDependentProperty(object):
     def _base_calculate(self, T, method):
         if method in self.tabular_data:
             return self.interpolate(T, method)
-        elif method in self.local_methods:
-            return self.local_methods[method][0](T)
+        elif method == USER_METHOD:
+            return self.user_method.f(T)
         elif method in self.correlations:
             call, kwargs, _ = self.correlations[method]
             return call(T, **kwargs)
@@ -2340,8 +2389,6 @@ class TDependentProperty(object):
     def _base_calculate_P(self, T, P, method):
         if method in self.tabular_data_P:
             return self.interpolate_P(T, P, method)
-#        elif method in self.local_methods_P:
-#            return self.local_methods_P[method][0](T, P)
         else:
             raise ValueError("Unknown method")
 
@@ -2355,7 +2402,7 @@ class TDependentProperty(object):
         try:
             T_low, T_high = self.T_limits[method]
             in_range = T_low <= T <= T_high
-        except (KeyError, AttributeError):
+        except KeyError:
             in_range = self.test_method_validity(T, method)
 
         if in_range:
@@ -2380,7 +2427,7 @@ class TDependentProperty(object):
         try:
             T_low, T_high = self.T_limits[method]
             in_range = T_low <= T <= T_high
-        except (KeyError, AttributeError):
+        except KeyError:
             in_range = self.test_method_validity(T, method)
 
         if in_range:
@@ -2428,7 +2475,7 @@ class TDependentProperty(object):
         try:
             T_low, T_high = self.T_limits[method]
             in_range = T_low <= T <= T_high
-        except (KeyError, AttributeError):
+        except KeyError:
             in_range = self.test_method_validity(T, method)
 
         if in_range:
@@ -2706,10 +2753,10 @@ class TDependentProperty(object):
     except:
         pass
 
-    def add_method(self, f, name, Tmin, Tmax, f_der_general=None,
-                   f_der=None, f_der2=None, f_der3=None, f_int=None,
-                   f_int_over_T=None):
-        r'''Method to add a new method and select it for future property
+    def set_user_method(self, f, Tmin=None, Tmax=None, 
+                        f_der=None, f_der2=None, f_der3=None,
+                        f_int=None, f_int_over_T=None):
+        r'''Define a new method and select it for future property
         calculations.
 
         Parameters
@@ -2717,16 +2764,10 @@ class TDependentProperty(object):
         f : callable
             Object which calculates the property given the temperature in K,
             [-]
-        name : str, optional
-            Name assigned to the data
         Tmin : float
             Minimum temperature to use the method at, [K]
         Tmax : float
             Maximum temperature to use the method at, [K]
-        f_der_general : callable or None
-            If specified, should take as arguments (T, order) and return the
-            derivative of the property at the specified temperature and
-            order, [-]
         f_der : callable or None
             If specified, should take as an argument the temperature and
             return the first derivative of the property, [-]
@@ -2750,13 +2791,12 @@ class TDependentProperty(object):
         method can no longer be used to reconstruct the object completely.
 
         '''
-        if not self.local_methods:
-            self.local_methods = local_methods = {}
-        local_methods[name] = (f, Tmin, Tmax, f_der_general, f_der, f_der2,
-                      f_der3, f_int, f_int_over_T)
-        self.T_limits[name] = (Tmin, Tmax)
+        self.user_method = user_method(f, f_der, f_der2, f_der3, f_int, f_int_over_T)
+        self._method = name = USER_METHOD
+        self.T_cached = None
         self.all_methods.add(name)
-        self.method = name
+        self.T_limits[name] = (0. if Tmin is None else Tmin,
+                               1e9 if Tmax is None else Tmax)
 
     def add_tabular_data(self, Ts, properties, name=None, check_properties=True):
         r'''Method to set tabular data to be used for interpolation.
@@ -2813,8 +2853,6 @@ class TDependentProperty(object):
         T : float
             Temperature at which the property is the specified value [K]
         '''
-#        if self.Tmin is None or self.Tmax is None:
-#            raise Exception('Both a minimum and a maximum value are not present indicating there is not enough data for temperature dependency.')
         if not self.test_property_validity(goal):
             raise ValueError('Input property is not considered plausible; no method would calculate it.')
 
@@ -2911,18 +2949,29 @@ class TDependentProperty(object):
                 return calls['f_der2'](T, **model_kwargs)
             elif order == 3 and 'f_der3' in calls:
                 return calls['f_der3'](T, **model_kwargs)
-
+        
+        Tmin, Tmax = self.T_limits[method]
+        in_range = Tmin <= T <= Tmax
+        if method == USER_METHOD and in_range:
+            user_method = self.user_method
+            if order == 1:
+                if user_method.f_der is not None: return user_method.f_der(T)
+            elif order == 2:
+                if user_method.f_der2 is not None: return user_method.f_der2(T)
+            elif order == 3:
+                if user_method.f_der3 is not None: return user_method.f_der3(T)
         pts = 1 + order*2
         dx = T*1e-6
-        args = [method]
-        Tmin, Tmax = self.T_limits[method]
-        if Tmin <= T <= Tmax:
+        args = (method,)
+        if in_range:
             # Adjust to be just inside bounds
             return derivative(self.calculate, T, dx=dx, args=args, n=order, order=pts,
                               lower_limit=Tmin, upper_limit=Tmax)
-        else:
+        elif self._extrapolation is not None:
             # Allow extrapolation
-            return derivative(self._T_dependent_property, T, dx=dx, args=args, n=order, order=pts)
+            return derivative(self.extrapolate, T, dx=dx, args=args, n=order, order=pts)
+        else:
+            raise ValueError("temperature is outside the valid range")
 #
 
     def T_dependent_property_derivative(self, T, order=1):
@@ -2984,8 +3033,10 @@ class TDependentProperty(object):
             calls = self.correlation_models[model][2]
             if 'f_int' in calls:
                 return calls['f_int'](T2, **model_kwargs) - calls['f_int'](T1, **model_kwargs)
-
-        return float(quad(self.calculate, T1, T2, args=(method,))[0])
+        if method == USER_METHOD and self.user_method.f_int is not None:
+            return self.user_method.f_int(T1, T2)
+        else:
+            return float(quad(self.calculate, T1, T2, args=(method,))[0])
 
     def T_dependent_property_integral(self, T1, T2):
         r'''Method to calculate the integral of a property with respect to
@@ -3047,9 +3098,10 @@ class TDependentProperty(object):
             calls = self.correlation_models[model][2]
             if 'f_int_over_T' in calls:
                 return calls['f_int_over_T'](T2, **model_kwargs) - calls['f_int_over_T'](T1, **model_kwargs)
-
-
-        return float(quad(lambda T: self.calculate(T, method)/T, T1, T2)[0])
+        elif method == USER_METHOD and self.user_method.f_int_over_T is not None:
+            return self.user_method.f_int_over_T(T1, T2)
+        else:
+            return float(quad(lambda T: self.calculate(T, method)/T, T1, T2)[0])
 
     def T_dependent_property_integral_over_T(self, T1, T2):
         r'''Method to calculate the integral of a property over temperature
@@ -3407,7 +3459,7 @@ class TDependentProperty(object):
                     break
         self.method = method
 
-    def load_all_methods(self):
+    def load_all_methods(self, load_data):
         pass
 
     def calculate(self, T, method):
@@ -3428,9 +3480,7 @@ class TDependentProperty(object):
         prop : float
             Calculated property, [`units`]
         '''
-        if method in self.tabular_data:
-            prop = self.interpolate(T, method)
-        return prop
+        return self._base_calculate(T, method)
 
     def test_method_validity(self, T, method):
         r'''Method to test the validity of a specified method for a given
@@ -3457,10 +3507,11 @@ class TDependentProperty(object):
         elif method == POLY_FIT:
             return True
         elif method in self.tabular_data:
-            if not self.tabular_extrapolation_permitted:
+            if self.tabular_extrapolation_permitted:
+                validity = True
+            else:
                 Ts, properties = self.tabular_data[method]
-                if T < Ts[0] or T > Ts[-1]:
-                    validity = False
+                validity = Ts[0] < T < Ts[-1]
         else:
             raise ValueError('Method not valid')
         return validity
@@ -3518,10 +3569,6 @@ class TPDependentProperty(TDependentProperty):
     interpolation_P = None
 
     def __init__(self, extrapolation, **kwargs):
-        self.user_methods_P = []
-        '''user_methods_P, list: Stored methods which were specified by the user
-        in a ranked order of preference; set by :obj:`TP_dependent_property <thermo.utils.TPDependentProperty.TP_dependent_property>`.'''
-        
         self.tabular_data_P = {}
         '''tabular_data_P, dict: Stored (Ts, Ps, properties) for any
         tabular data; indexed by provided or autogenerated name.'''
@@ -3701,7 +3748,6 @@ class TPDependentProperty(TDependentProperty):
             prop = self.T_dependent_property(T)
         return prop
 
-
     def add_tabular_data_P(self, Ts, Ps, properties, name=None, check_properties=True):
         r'''Method to set tabular data to be used for interpolation.
         Ts and Psmust be in increasing order. If no name is given, data will be
@@ -3742,8 +3788,40 @@ class TPDependentProperty(TDependentProperty):
             name = 'Tabular data series #' + str(len(self.tabular_data))  # Will overwrite a poorly named series
         self.tabular_data_P[name] = [Ts, Ps, properties]
         self.all_methods_P.add(name)
-
         self.method_P = name
+
+    def test_method_validity_P(self, T, P, method):
+        r'''Method to test the validity of a specified method for a given
+        temperature. Demo function for testing only;
+        must be implemented according to the methods available for each
+        individual method. Include the interpolation check here.
+
+        Parameters
+        ----------
+        T : float
+            Temperature at which to determine the validity of the method, [K]
+        P : float
+            Pressure at which to determine the validity of the method, [Pa]
+        method : str
+            Method name to use
+
+        Returns
+        -------
+        validity : bool
+            Whether or not a specifid method is valid
+        '''
+        if method in self.tabular_data:
+            if self.tabular_extrapolation_permitted:
+                validity = True
+            else:
+                Ts, Ps, properties = self.tabular_data[method]
+                validity = Ts[0] < T < Ts[-1] and Ps[0] < P < Ps[-1]
+        elif method in self.all_methods_P:
+            Tmin, Tmax = self.T_limits[method]
+            validity = Tmin < T < Tmax
+        else:
+            raise ValueError('Method not valid')
+        return validity
 
     def interpolate_P(self, T, P, name):
         r'''Method to perform interpolation on a given tabular data set
@@ -4054,7 +4132,7 @@ class TPDependentProperty(TDependentProperty):
                 raise Exception('Maximum pressure could not be auto-detected; please provide it')
 
         if not methods_P:
-            methods_P = self.user_methods_P if self.user_methods_P else self.all_methods_P
+            methods_P = self.all_methods_P
         Ps = np.linspace(Pmin, Pmax, pts)
         Ts = np.linspace(Tmin, Tmax, pts)
         Ts_mesh, Ps_mesh = np.meshgrid(Ts, Ps)
@@ -4304,10 +4382,6 @@ class MixtureProperty(object):
         '''Maximum temperature at which no method can calculate the
         property above.'''
 
-        self.user_methods = []
-        '''user_methods, list: Stored methods which were specified by the user
-        in a ranked order of preference; set by :obj:`mixture_property <thermo.utils.MixtureProperty.mixture_property>`.'''
-        
         self.all_methods = set()
         '''Set of all methods available for a given set of information;
         filled by :obj:`load_all_methods`.'''

--- a/thermo/vapor_pressure.py
+++ b/thermo/vapor_pressure.py
@@ -263,7 +263,6 @@ class VaporPressure(TDependentProperty):
         self.Pc = Pc
         self.omega = omega
         self.eos = eos
-
         super(VaporPressure, self).__init__(extrapolation, **kwargs)
 
     @staticmethod
@@ -714,7 +713,6 @@ class SublimationPressure(TDependentProperty):
         self.Tt = Tt
         self.Pt = Pt
         self.Hsub_t = Hsub_t
-
         super(SublimationPressure, self).__init__(extrapolation, **kwargs)
 
     def load_all_methods(self, load_data=True):

--- a/thermo/viscosity.py
+++ b/thermo/viscosity.py
@@ -329,8 +329,6 @@ class ViscosityLiquid(TPDependentProperty):
         self.Vml = Vml
         super(ViscosityLiquid, self).__init__(extrapolation, **kwargs)
 
-
-
     def load_all_methods(self, load_data=True):
         r'''Method which picks out coefficients for the specified chemical
         from the various dictionaries and DataFrames storing it. All data is
@@ -832,7 +830,6 @@ class ViscosityGas(TPDependentProperty):
         self.Vmg = Vmg
         super(ViscosityGas, self).__init__(extrapolation, **kwargs)
 
-
     def load_all_methods(self, load_data=True):
         r'''Method which picks out coefficients for the specified chemical
         from the various dictionaries and DataFrames storing it. All data is
@@ -892,10 +889,6 @@ class ViscosityGas(TPDependentProperty):
         self.all_methods_P = set(methods_P)
         if Tmins and Tmaxs:
             self.Tmin, self.Tmax = min(Tmins), max(Tmaxs)
-        for m in self.ranked_methods_P:
-            if m in self.all_methods_P:
-                self.method_P = m
-                break
 
     @staticmethod
     def _method_indexes():

--- a/thermo/volume.py
+++ b/thermo/volume.py
@@ -898,22 +898,6 @@ class VolumeSupercriticalLiquid(VolumeLiquid):
         if an interpolation transform is altered, the old interpolator which
         had been created is no longer used.'''
 
-        self.sorted_valid_methods = []
-        '''sorted_valid_methods, list: Stored methods which were found valid
-        at a specific temperature; set by :obj:`T_dependent_property <thermo.utils.TDependentProperty.T_dependent_property>`.'''
-        self.sorted_valid_methods_P = []
-        '''sorted_valid_methods_P, list: Stored methods which were found valid
-        at a specific temperature; set by :obj:`TP_dependent_property <thermo.utils.TPDependentProperty.TP_dependent_property>`.'''
-        self.user_methods_P = []
-        '''user_methods_P, list: Stored methods which were specified by the user
-        in a ranked order of preference; set by :obj:`TP_dependent_property <thermo.utils.TPDependentProperty.TP_dependent_property>`.'''
-
-        self.all_methods = set()
-        '''Set of all low-pressure methods available for a given CASRN and
-        properties; filled by :obj:`load_all_methods`.'''
-        self.all_methods_P = set()
-        '''Set of all high-pressure methods available for a given CASRN and
-        properties; filled by :obj:`load_all_methods`.'''
         self.load_all_methods()
         self.extrapolation = extrapolation
 


### PR DESCRIPTION
Hi Caleb,

I would like to propose a new API for setting user methods. I do realize that one is already in place (https://thermo.readthedocs.io/property_objects.html#adding-new-methods), but it's still incomplete and untested enough that I think a new implementation may work better. 

I'll first note a few minor issues with the current implementation for user or "local" methods:
* It allows users to add methods multiple times, but I don't think anyone is actually dependent on this feature because it has a bug that doesn't let it run twice. Perhaps this feature made sense when thermo would loop through methods to find one that works, but with extrapolation implemented, just one method should be enough. From my own experience with biosteam users, no user has ever tried to add multiple "methods".
* The derivative and integration functions passed by the user are not actually used (code still incomplete).
* `add_method` is not tested in CI (I checked the coverage).
* Having a tuple of all the functions would make it a bit hard to read and write (maybe an object with slots would be better?).

With this pull request, I propose a "set_user_method" method which allows for only one user method. All the derivatives and integrals are working as they should (tests have been added with full coverage and all tests passing). I made this function with biosteam users in mind, so there are a few convenience features you might take notice of.  It would be straight forward to add a similar "add_user_method_P" method for pressure-dependent methods, but this is not too important for me yet. 

This pull request draft is not urgent, so feel free come back to this later if you need to think about the implementation more.

Thanks again!


