### PR TITLE
User now can install sqllite with own connection params.

### DIFF
--- a/tests/test_unifac.py
+++ b/tests/test_unifac.py
@@ -1090,18 +1090,25 @@ def test_UNIFAC_group_assignment_DDBST():
     assert UNIFAC_group_assignment_DDBST('50-37-3', 'MODIFIED_UNIFAC') == {1: 2, 8: 1, 9: 3, 10: 3, 34: 1, 38: 1, 78: 2, 79: 2, 103: 1}
 
 
-def test_unifac_sql_connection():
+def test_unifac_sql_connection_check_threading_false():
+    import threading
     # given is the module interface
     from thermo import unifac
-    from pathlib import Path
-    # when user wants to adjust params of sql connection
-    con_params = dict(
-        database=Path(unifac.__file__).parent / Path(r".\Phase Change\DDBST_UNIFAC_assignments.sqlite"),
-        check_same_thread=True
-    )
-    unifac.init_ddbst_UNIFAC_db(**con_params)
-    # then connection reflects
-    c: sqlite3.Cursor = unifac.UNIFAC_DDBST_ASSIGNMENT_CURSOR
-    assert c is not None
-    assert UNIFAC_group_assignment_DDBST('50-14-6', 'UNIFAC') == {1: 5, 2: 8, 3: 6, 4: 1, 6: 1, 7: 1, 8: 2, 14: 1}
+    # and the interface has init the database connection
+    unifac.init_ddbst_UNIFAC_db()
+    assert unifac.UNIFAC_DDBST_ASSIGNMENT_CURSOR is not None
+    # when user querying UNIFAC from different threads
+
+    def worker(raised_exception: threading.Event):
+        try:
+            UNIFAC_group_assignment_DDBST('50-14-6', 'UNIFAC')
+        except Exception:
+            raised_exception.set()
+
+    raised = threading.Event()
+    t = threading.Thread(target=worker, args=(raised,))
+    t.start()
+    t.join()
+    # then no exception is raised on any thread
+    assert not raised.is_set()
 

--- a/tests/test_unifac.py
+++ b/tests/test_unifac.py
@@ -22,6 +22,7 @@ SOFTWARE.
 
 import json
 import pickle
+import sqlite3
 import types
 from math import *
 
@@ -1087,3 +1088,20 @@ def test_UNIFAC_group_assignment_DDBST():
     assert {} == UNIFAC_group_assignment_DDBST('50-37-3', 'PSRK')
     assert {} == UNIFAC_group_assignment_DDBST('50-37-3', 'UNIFAC')
     assert UNIFAC_group_assignment_DDBST('50-37-3', 'MODIFIED_UNIFAC') == {1: 2, 8: 1, 9: 3, 10: 3, 34: 1, 38: 1, 78: 2, 79: 2, 103: 1}
+
+
+def test_unifac_sql_connection():
+    # given is the module interface
+    from thermo import unifac
+    from pathlib import Path
+    # when user wants to adjust params of sql connection
+    con_params = dict(
+        database=Path(unifac.__file__).parent / Path(r".\Phase Change\DDBST_UNIFAC_assignments.sqlite"),
+        check_same_thread=True
+    )
+    unifac.init_ddbst_UNIFAC_db(**con_params)
+    # then connection reflects
+    c: sqlite3.Cursor = unifac.UNIFAC_DDBST_ASSIGNMENT_CURSOR
+    assert c is not None
+    assert UNIFAC_group_assignment_DDBST('50-14-6', 'UNIFAC') == {1: 5, 2: 8, 3: 6, 4: 1, 6: 1, 7: 1, 8: 2, 14: 1}
+

--- a/thermo/unifac.py
+++ b/thermo/unifac.py
@@ -2618,13 +2618,12 @@ def load_group_assignments_DDBST():
 ## Database lookup
 UNIFAC_DDBST_ASSIGNMENT_CURSOR = None
 
-def init_ddbst_UNIFAC_db(**connection_params):
+def init_ddbst_UNIFAC_db():
     global UNIFAC_DDBST_ASSIGNMENT_CURSOR
     import sqlite3
-    if "database" not in connection_params:
-        connection_params["database"] = os.path.join(os.path.dirname(__file__), 'Phase Change', 'DDBST_UNIFAC_assignments.sqlite')
     conn = sqlite3.connect(
-        **connection_params
+        os.path.join(os.path.dirname(__file__), 'Phase Change', 'DDBST_UNIFAC_assignments.sqlite'),
+        check_same_thread=False,
     )
     UNIFAC_DDBST_ASSIGNMENT_CURSOR = conn.cursor()
 

--- a/thermo/unifac.py
+++ b/thermo/unifac.py
@@ -2618,10 +2618,14 @@ def load_group_assignments_DDBST():
 ## Database lookup
 UNIFAC_DDBST_ASSIGNMENT_CURSOR = None
 
-def init_ddbst_UNIFAC_db():
+def init_ddbst_UNIFAC_db(**connection_params):
     global UNIFAC_DDBST_ASSIGNMENT_CURSOR
     import sqlite3
-    conn = sqlite3.connect(os.path.join(os.path.dirname(__file__), 'Phase Change', 'DDBST_UNIFAC_assignments.sqlite'))
+    if "database" not in connection_params:
+        connection_params["database"] = os.path.join(os.path.dirname(__file__), 'Phase Change', 'DDBST_UNIFAC_assignments.sqlite')
+    conn = sqlite3.connect(
+        **connection_params
+    )
     UNIFAC_DDBST_ASSIGNMENT_CURSOR = conn.cursor()
 
 def UNIFAC_group_assignment_DDBST(CAS, model):


### PR DESCRIPTION
However, needs to be called before unifac interface is used somewhere else.

See issue
#140 