### PR TITLE
StreamArgs.copy() breaks lisp

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -247,7 +247,34 @@ def test_sub_streams():
     assert m.CASs == ['7732-18-5']
 
 
+@pytest.fixture(
+    params=[
+        (StreamArgs,{}),
+        (EnergyStream,dict(Q=0))
+    ],
+    ids="StreamArgs EnergyStream".split()
+)
+def any_type_of_stream(request):
+    return request.param
 
+def test_stream_copy(any_type_of_stream):
+    stream_type, param = any_type_of_stream
+    expected_args = stream_type(**param)
+    # when copied
+    stream_copy = expected_args.copy()
+    # then
+    assert isinstance(stream_copy, stream_type)
+
+def test_child_class_copy(any_type_of_stream):
+    # lets say user wants to enhance StreamArgs class by:
+    stream_type, param = any_type_of_stream
+    class EnhancedStreamArgs(stream_type):
+        pass
+    expected_args = EnhancedStreamArgs(**param)
+    # when copied
+    stream_copy = expected_args.copy()
+    # then
+    assert isinstance(stream_copy, EnhancedStreamArgs)
 
 
 def test_StreamArgs_flow_overspecified():

--- a/thermo/stream.py
+++ b/thermo/stream.py
@@ -382,7 +382,7 @@ class StreamArgs:
             kwargs['Vfgs'] = [i for i in kwargs['Vfgs']]
         if kwargs['Vfls'] is not None:
             kwargs['Vfls'] = [i for i in kwargs['Vfls']]
-        return StreamArgs(Vf_TP=self.Vf_TP, Q_TP=self.Q_TP, flasher=self.flasher,
+        return self.__class__(Vf_TP=self.Vf_TP, Q_TP=self.Q_TP, flasher=self.flasher,
                  multiple_composition_basis=self.multiple_composition_basis, **kwargs)
 
     __copy__ = copy
@@ -2996,7 +2996,7 @@ class EnergyStream:
         copy : EnergyStream
             Copied Energy Stream, [-]
         '''
-        return EnergyStream(Q=self.Q)
+        return self.__class__(Q=self.Q)
 
     __copy__ = copy
 

--- a/thermo/stream.py
+++ b/thermo/stream.py
@@ -71,11 +71,11 @@ class StreamArgs:
     Handling flow flow vs. composition is fuzzier because of the common use cases
     where a flow rate may be known, but not composition; or the composition but not
     the flow, however later when the product
-    flows are known it is desireable to set it. To allow this,
+    flows are known it is desirable to set it. To allow this,
     the variables `ns`, `ms`, `Qls`, and `Qgs` are allowed to overwrite an existing
     flow and/or composition specification even if if `multiple_composition_basis` is False.
 
-    Eveen if the property wasn't set to this object, but if enough degrees of freedom
+    Even if the property wasn't set to this object, but if enough degrees of freedom
     are known, the actual value can usually be queried by adding `_calc` to the attribute,
     e.g. `H_calc` is available if `T`, `P`, and `zs` are known. This will perform the
     flash if it hasn't already been done.


### PR DESCRIPTION
Hello Caleb,

A user class derived from StreamArgs or EnergyStream will fail to properly copy the object.
Instead of direct construction the type we leave it to the class itself to construct the correct type.

cheers simon