### PR TITLE
Assume `f_der` methods can be tuples

### DIFF
--- a/tests/test_viscosity.py
+++ b/tests/test_viscosity.py
@@ -474,6 +474,14 @@ def test_ViscosityLiquid_PPDS9_limits():
 #    obj = ViscosityLiquid(CASRN='75-71-8', Tm=115.15, Tc=385.0)
 #    low, high = obj.T_limits[VDI_PPDS]
 
+@pytest.mark.meta_T_dept
+def test_ViscosityLiquid_PPDS9_extrapolation():
+    # Make sure extrapolation works using derivative from chemicals.viscosity.dPPDS9_dT
+    mu = ViscosityLiquid(CASRN="91-57-6", MW=142.1971, Tm=306.85, Tc=761.0, Pc=3370000.0, Vc=0.000464, omega=0.3464, Psat=VaporPressure(CASRN="91-57-6", Tb=514.25, Tc=761.0, Pc=3370000.0, omega=0.3464, extrapolation="AntoineAB|DIPPR101_ABC", method="WAGNER_MCGARRY", Tmin=412.0, Tmax=761.0), Vml=VolumeLiquid(CASRN="91-57-6", MW=142.1971, Tb=514.25, Tc=761.0, Pc=3370000.0, Vc=0.000464, Zc=0.24713203171249656, omega=0.3464, dipole=0.4, Psat=VaporPressure(CASRN="91-57-6", Tb=514.25, Tc=761.0, Pc=3370000.0, omega=0.3464, extrapolation="AntoineAB|DIPPR101_ABC", method="WAGNER_MCGARRY", Tmin=412.0, Tmax=761.0), extrapolation="constant", method="VDI_PPDS", method_P="COSTALD_COMPRESSED", tabular_extrapolation_permitted=True, Tmin=228.29999999999998, Tmax=761.0), extrapolation="Arrhenius", method="VDI_PPDS", method_P="LUCAS", tabular_extrapolation_permitted=True, Tmin=306.85, Tmax=577.1663137027967)
+    actual = mu(300, 0.2 * 101325)
+    assert mu.T_limits['VDI_PPDS'][0] > 300 # Make sure testing for extrapolation
+    assert_close(actual, 0.0021504854722795615)
+
 @pytest.mark.skip
 @pytest.mark.slow
 @pytest.mark.fitting

--- a/thermo/utils/t_dependent_property.py
+++ b/thermo/utils/t_dependent_property.py
@@ -784,7 +784,7 @@ class TDependentProperty:
     "PPDS5": (["Tc", "a0", "a1", "a2"], [], {"f": PPDS5}, {"fit_params": ["a0", "a1", "a2"]},),
     "mu_TDE": (["A", "B", "C", "D"], [], {"f": mu_TDE}, {"fit_params": ["A", "B", "C", "D"]},),
 
-    "PPDS9": (["A", "B", "C", "D", "E"], [], {"f": PPDS9, "f_der": dPPDS9_dT}, {"fit_params": ["A", "B", "C", "D", "E"]},),
+    "PPDS9": (["A", "B", "C", "D", "E"], [], {"f": PPDS9, "f_der": lambda T, A, B, C, D, E: dPPDS9_dT(T, A, B, C, D, E)[0]}, {"fit_params": ["A", "B", "C", "D", "E"]},),
     "mu_Yaws": (["A", "B",], ["C", "D"], {"f": mu_Yaws, "f_der": dmu_Yaws_dT}, {"fit_params": ["A", "B", "C", "D"], "initial_guesses": [
         {"A": -9.45, "B": 1120.0, "C": 0.014, "D": -1.545e-5}, # near yaws ethanol
         {"A": -25.5319, "B": 3747.19, "C": 0.04659, "D": -0.0}, # near yaws 1-phenyltetradecane
@@ -3979,14 +3979,11 @@ class TDependentProperty:
 
             calls = self.correlation_models[model][2]
             if order == 1 and "f_der" in calls:
-                value = calls["f_der"](T, **kwargs)
-                return value[0] if isinstance(value, tuple) else value
+                return calls["f_der"](T, **kwargs)
             elif order == 2 and "f_der2" in calls:
-                value = calls["f_der2"](T, **kwargs)
-                return value[0] if isinstance(value, tuple) else value
+                return calls["f_der2"](T, **kwargs)
             elif order == 3 and "f_der3" in calls:
-                value = calls["f_der3"](T, **kwargs)
-                return value[0] if isinstance(value, tuple) else value
+                return calls["f_der3"](T, **kwargs)
 
         if method in self.local_methods:
             local_method = self.local_methods[method]

--- a/thermo/utils/t_dependent_property.py
+++ b/thermo/utils/t_dependent_property.py
@@ -3979,11 +3979,14 @@ class TDependentProperty:
 
             calls = self.correlation_models[model][2]
             if order == 1 and "f_der" in calls:
-                return calls["f_der"](T, **kwargs)
+                value = calls["f_der"](T, **kwargs)
+                return value[0] if isinstance(value, tuple) else value
             elif order == 2 and "f_der2" in calls:
-                return calls["f_der2"](T, **kwargs)
+                value = calls["f_der2"](T, **kwargs)
+                return value[0] if isinstance(value, tuple) else value
             elif order == 3 and "f_der3" in calls:
-                return calls["f_der3"](T, **kwargs)
+                value = calls["f_der3"](T, **kwargs)
+                return value[0] if isinstance(value, tuple) else value
 
         if method in self.local_methods:
             local_method = self.local_methods[method]


### PR DESCRIPTION
@CalebBell,

I ran into this bug with extrapolating the viscosity of a chemical. The issue comes from the `TDependentProperty` object assuming that all `f_der` methods return floats. For the special case of  `chemicals.viscosity.dPPDS9_dT`, it returns a tuple with the first value being the derivative, the second being the actual viscosity. 

You can reproduce the error as follows:

```python
from thermo import Chemical
chemical = Chemical('2-methylnaphthalene')
chemical.ViscosityLiquid(300, 0.2 * 101325)
chemical.ViscosityLiquid.RAISE_PROPERTY_CALCULATION_ERROR = True
chemical.ViscosityLiquid.TP_dependent_property(300, 0.2 * 101325)
```
```
RuntimeError: Failed to evaluate liquid viscosity method 'LUCAS' at T=300 K and P=20265.0 Pa for component with CASRN '91-57-6'
```

In this pull request, I added additional logic to accommodate this special case with tuples. Then the return value is `0.0021504854722795615`.

If you approve of this change, I can go ahead and add this case as a test.

Thanks!